### PR TITLE
Added POSTGRES_HOST_AUTH_METHOD env

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
   db:
     environment:
       POSTGRES_USER: postgres
+      POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_PASSWORD:
     image: postgres:9.6
     expose:


### PR DESCRIPTION
db container does not start on ubuntu 18 without env

Error: Database is uninitialized and superuser password is not specified.
You must specify POSTGRES_PASSWORD to a non-empty value for the
superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".

You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
connections without a password. This is *not* recommended.

See PostgreSQL documentation about "trust":
https://www.postgresql.org/docs/current/auth-trust.html
